### PR TITLE
EventMeta Definition: Set parition key to constant

### DIFF
--- a/bootstrap/cassandra.go
+++ b/bootstrap/cassandra.go
@@ -182,7 +182,7 @@ func initCassandra(
 	return c.ensureKeyspaceTable()
 }
 
-// Event create the event table if it doesn't exist.
+// Event creates the event table if it doesn't exist.
 // This also returns the go-cassandrautils table reference to the table.
 // Following env vars can be used for configuration:
 //  CASSANDRA_HOSTS
@@ -196,7 +196,7 @@ func Event() (*csndra.Table, error) {
 	return initCassandra(definition.Event(), tableName)
 }
 
-// EventMeta create the event-meta table if it doesn't exist.
+// EventMeta creates the event-meta table if it doesn't exist.
 // This also returns the go-cassandrautils table reference to the table.
 // Following env vars can be used for configuration:
 //  CASSANDRA_HOSTS

--- a/definition/event_meta.go
+++ b/definition/event_meta.go
@@ -19,8 +19,8 @@ func EventMeta() map[string]csndra.TableColumn {
 				DataType:        "int",
 				PrimaryKeyIndex: "1",
 			},
-			"yearBucket": csndra.TableColumn{
-				Name:            "year_bucket",
+			"partitionKey": csndra.TableColumn{
+				Name:            "partition_key",
 				DataType:        "smallint",
 				PrimaryKeyIndex: "0",
 			},


### PR DESCRIPTION
EventMeta table will not have as many rows compared to Event table. In fact, it will have very little rows, and so having YearBucket as partition key doesn't make sense since it only stores single field per aggregate.

The new partition key is a simple constant `key`, whose value can be kept consistent across the project.