### PR TITLE
Use TimeUUID as Event-ID

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,24 +13,24 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:dcade65c88d17fe1841540f1f1f841941cf11f153a26fad02451f263a71490f1"
+  digest = "1:9e040726ee775fa241bf96d3c11533a5312d9bcb00a594b63679bff456a4522c"
   name = "github.com/TerrexTech/go-commonutils"
   packages = ["commonutil"]
   pruneopts = "UT"
-  revision = "bec34e895c0ef90d7b0452f141691767356ae6e4"
-  version = "v3.0.0"
+  revision = "3d09c974f936d001def7acafb178d99f317ee3a9"
+  version = "v3.1.0"
 
 [[projects]]
-  digest = "1:ce36c38655294f7a1c19b96c01ef0e94a843773e289de557c754dc3756c514a4"
+  digest = "1:68c3fd9d39b68bc44df2ffab40bc64cb2569989d0500dfcdf304ea9b23f6e811"
   name = "github.com/TerrexTech/uuuid"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a29ab526ee6513a1fd0195b41a921f305298b1c2"
-  version = "v1.0.0"
+  revision = "878f821b0790deac123bca2d170ac5cd5c9a527e"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:41cbe73cce1dd0e86e2223ca5deecf41c374643c82ec2b56f78bc4e7cad24f83"
+  digest = "1:b74776d049e50a23a2b21182910b53a7e5f4834a9703381b9ed623c71163f7d7"
   name = "github.com/gocql/gocql"
   packages = [
     ".",
@@ -39,7 +39,7 @@
     "internal/streams",
   ]
   pruneopts = "UT"
-  revision = "799fb0373110eaa4e2e71dd32a9b5903f80dca8f"
+  revision = "f0078a2a1998b932af7c3eed2b3b7980aef73c43"
 
 [[projects]]
   digest = "1:ce579162ae1341f3e5ab30c0dce767f28b1eb6a81359aad01723f1ba6b4becdf"
@@ -157,7 +157,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c85f5fc06e706d2e47979c95633d90e1293356446c876383d466f0054d19e731"
+  digest = "1:5193d913046443e59093d66a97a40c51f4a5ea4ceba60f3b3ecf89694de5d16f"
   name = "golang.org/x/net"
   packages = [
     "html",
@@ -165,15 +165,15 @@
     "html/charset",
   ]
   pruneopts = "UT"
-  revision = "2f5d2388922f370f4355f327fcf4cfe9f5583908"
+  revision = "49bb7cea24b1df9410e1712aa6433dae904ff66a"
 
 [[projects]]
   branch = "master"
-  digest = "1:6c54cefa33de85c47075aae30f1d1a333967c405272010bb76aa943467e4cbae"
+  digest = "1:0a40b0bdd57a93e741d8557465be3a2edeec408e9b6399586ad65bbe8e355796"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "d47a0f3392421c5624713c9a19fe781f651f8a50"
+  revision = "fa43e7bc11baaae89f3f902b2b4d832b68234844"
 
 [[projects]]
   digest = "1:aa4d6967a3237f8367b6bf91503964a77183ecf696f1273e8ad3551bb4412b5f"
@@ -243,7 +243,6 @@
     "github.com/TerrexTech/go-commonutils/commonutil",
     "github.com/TerrexTech/uuuid",
     "github.com/gocql/gocql",
-    "github.com/gofrs/uuid",
     "github.com/joho/godotenv",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",

--- a/bootstrap/cassandra_test.go
+++ b/bootstrap/cassandra_test.go
@@ -91,15 +91,19 @@ var _ = Describe("Event", func() {
 		cid, err := uuuid.NewV4()
 		Expect(err).ToNot(HaveOccurred())
 
-		u, _ := uuuid.NewV4()
+		uid, err := uuuid.NewV4()
+		Expect(err).ToNot(HaveOccurred())
+		tid, err := uuuid.NewV1()
+		Expect(err).ToNot(HaveOccurred())
+
 		e1 := &model.Event{
 			Action:        "insert",
 			AggregateID:   1,
 			CorrelationID: cid,
 			Data:          []byte(""),
 			Timestamp:     time.Now(),
-			UserUUID:      u,
-			UUID:          u,
+			UserUUID:      uid,
+			TimeUUID:      tid,
 			Version:       1,
 			YearBucket:    2018,
 		}

--- a/definition/event.go
+++ b/definition/event.go
@@ -11,7 +11,7 @@ func Event() map[string]csndra.TableColumn {
 			"action": csndra.TableColumn{
 				Name:            "action",
 				DataType:        "text",
-				PrimaryKeyIndex: "3",
+				PrimaryKeyIndex: "4",
 			},
 			"aggregateID": csndra.TableColumn{
 				Name:            "aggregate_id",
@@ -27,19 +27,18 @@ func Event() map[string]csndra.TableColumn {
 				DataType: "blob",
 			},
 			"timestamp": csndra.TableColumn{
-				Name:            "timestamp",
-				DataType:        "timestamp",
-				PrimaryKeyIndex: "4",
-				PrimaryKeyOrder: "DESC",
+				Name:     "timestamp",
+				DataType: "timestamp",
 			},
 			"userUUID": csndra.TableColumn{
 				Name:     "user_uuid",
 				DataType: "uuid",
 			},
-			"uuid": csndra.TableColumn{
-				Name:            "uuid",
-				DataType:        "uuid",
-				PrimaryKeyIndex: "5",
+			"timeUUID": csndra.TableColumn{
+				Name:            "time_uuid",
+				DataType:        "timeuuid",
+				PrimaryKeyIndex: "3",
+				PrimaryKeyOrder: "DESC",
 			},
 			"version": csndra.TableColumn{
 				Name:            "version",

--- a/model/event.go
+++ b/model/event.go
@@ -27,11 +27,11 @@ type Event struct {
 	// Timestamp is the time when the event was generated.
 	Timestamp time.Time `cql:"timestamp" json:"timestamp"`
 
-	// UserUUID is the UUID of the user who generated the event.
+	// UserUUID is the V4-UUID of the user who generated the event.
 	UserUUID uuuid.UUID `cql:"user_uuid" json:"user_uuid"`
 
-	// UUID is the unique-indentifier for event.
-	UUID uuuid.UUID `cql:"uuid" json:"uuid"`
+	// TimeUUID is the V1-UUID unique-indentifier for event.
+	TimeUUID uuuid.UUID `cql:"time_uuid" json:"time_uuid"`
 
 	// Version is the version for events as processed for aggregate-projection.
 	// This is incremented by the aggregate itself each time it updates its

--- a/model/eventstore_query.go
+++ b/model/eventstore_query.go
@@ -20,4 +20,7 @@ type EventStoreQuery struct {
 
 	// YearBucket is the partition-key for Event-Table.
 	YearBucket int16 `json:"year_bucket"`
+
+	// UUID is the V4-UUID Query-Identifier.
+	UUID uuuid.UUID `json:"uuid,omitempty"`
 }

--- a/model/kafka_response.go
+++ b/model/kafka_response.go
@@ -15,10 +15,6 @@ type KafkaResponse struct {
 	// responses generated as per result of event's processing.
 	CorrelationID uuuid.UUID `json:"correlation_id,omitempty"`
 
-	// Input is the data that was being processed.
-	// Use this to provide context of whatever data was attempted to be processed.
-	Input []byte `json:"input,omitempty"`
-
 	// Error is the error occurred while processing the Input.
 	// Convert errors to strings, this is just an indication that
 	// something went wrong, so we can signal/display-error to end-
@@ -28,6 +24,10 @@ type KafkaResponse struct {
 	// ErrorCode can be used to identify type of error.
 	ErrorCode int16 `json:"error_code,omitempty"`
 
+	// Input is the data that was being processed.
+	// Use this to provide context of whatever data was attempted to be processed.
+	Input []byte `json:"input,omitempty"`
+
 	// Result is the result after an input was processed.
 	// This is some data returned by processing (such as database results) etc.
 	Result []byte `json:"result,omitempty"`
@@ -36,4 +36,7 @@ type KafkaResponse struct {
 	// This field will not be included as part of the response, and is only
 	// for referencing purposes for producer.
 	Topic string `json:"-"`
+
+	// UUID is the V4-UUID Response-Identifier.
+	UUID uuuid.UUID `json:"uuid,omitempty"`
 }


### PR DESCRIPTION
Reason:
https://github.com/TerrexTech/go-eventstore-query/issues/7

Also added `UUID` to KafkaResponse and EventStoreQuery because earlier `CorrelationID` was being used as an identifier, while its meant to relate Events. UUID will be the proper identifier.